### PR TITLE
change location to Taipei

### DIFF
--- a/src/components/HeroImage.vue
+++ b/src/components/HeroImage.vue
@@ -254,8 +254,7 @@
             <tspan x="100" y="836">
               <tspan v-if="lang==='TW'">中央研究院人文館</tspan>
               <tspan v-else>
-                <tspan>Joint Library of Humanities and Social Sciences,</tspan>
-                <tspan x="100" y="864">Academia Sinica</tspan>
+                <tspan>Taipei</tspan>
               </tspan>
               <tspan>
                 <!-- <tspan v-if="lang==='TW'">/ 台北市南港區研究院路二段128號</tspan> -->


### PR DESCRIPTION
highlight Taipei for international participants because they don't need to know the exact location in Taipei.