### PR TITLE
🚧資料完成再merge🚧  公開議程頁面（/agenda）的連結

### DIFF
--- a/src/views/NavBar.vue
+++ b/src/views/NavBar.vue
@@ -12,10 +12,10 @@
     .top-bar-right
       ul.menu
         //- TODO: add for later version
-        //- li
-        //-   UnderlineLink(to="/schedule").disabled
-        //-     TW 議程
-        //-     EN Schedule
+        li
+          UnderlineLink(to="/agenda").disabled
+            TW 議程
+            EN Agenda
         //- li
         //-   UnderlineLink(to="/speakers")
         //-     TW 講者


### PR DESCRIPTION
# 更新內容
在 #79 中已完成了 Agenda 頁面大部分功能，也已上線（https://summit.g0v.tw/2018/agenda/ ），在這個 PR 釋出導覽列上的連結

# 釋出前完成（by 議程組）
- [ ] 把部分確定的議程填入 Airtable 的 [SCHEDULE](https://airtable.com/invite/l?inviteId=invgmSI7Kq7mpXF1B&inviteToken=d6b766cf10cd76391e5868e419c73b1174fec5c1b1ad322e972f256b0f9a016c) 表格，覆蓋掉目前的假資料
- [ ] 確認這邊 https://summit.g0v.tw/2018/agenda/ 的 (部分) 內容是可以公開的
- [ ] 點綠色的 Merge 按鈕
- [ ] 等 Travis CI 跑約 5 分鐘後就會上線囉

# 未完成 TODO（暫不影響釋出）
- 手機版
- 點擊議程後跳出 Dialog 之類的，顯示摘要、簡報連結、YouTube
   **p.s. 如果 8/3 前有需要動工這個的話可以從 [AgendumCell.vue](https://github.com/g0v/summit2018/blob/master/src/components/AgendumCell.vue) 著手**