### PR TITLE
🎨(SpeakerPage) Use .large-up-5 instead of spacers

### DIFF
--- a/src/pages/SpeakerPage.vue
+++ b/src/pages/SpeakerPage.vue
@@ -1,11 +1,7 @@
 <template>
   <section id="speaker-page" class="grid-container">
-    <div class="grid-x grid-margin-x">
-      <template v-for="(speaker, index) in speakers">
-        <!-- Spacers push five <SpeakerIntro/> in a row -->
-        <div v-if="index!==0&&index%5===0" :key="`1st-spacer:${speaker.id}`" class="spacer cell large-1 medium-0 small-0"/>
-        <div v-if="index%5===0" :key="`2nd-spacer:${speaker.id}`" class="spacer cell large-1 medium-0 small-0"/>
-
+    <div class="grid-x grid-margin-x large-up-5">
+      <template v-for="speaker in speakers">
         <!-- Speaker avatar and title -->
         <SpeakerIntro
           :key="`speaker-intro:${speaker.id}`"
@@ -38,10 +34,5 @@ export default {
 #speaker-page {
   margin-top: 140px;
   margin-bottom: 140px;
-
-  // TODO: Spacers are used to get five <SpeakerInfo/> in a row. Try better approch.
-  // .spacer {
-  //   border: 1px dashed green;
-  // }
 }
 </style>


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/12410942/43049186-de24588e-8e25-11e8-9c3c-53d934b32026.png)

# After
![image](https://user-images.githubusercontent.com/12410942/43049181-cb3fb7f4-8e25-11e8-8bbd-551a2280a4f6.png)
