### PR TITLE
Add (not so useful) g0v summit 2018 API (documentation only, actually)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Airtable data (get it via $ yarn run pull_airtable)
+static/api/
 static/airtable_data/*.json
 
 # Build output

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 [網站開發進度 Trello](https://trello.com/c/PUH4VaGS/19-%E4%B8%80%E9%A0%81%E5%BC%8F%E7%B6%B2%E7%AB%99%E9%96%8B%E7%99%BC)
 
+## API
+
+https://g0v.github.io/summit2018/static/api
+
+提供 2018 summit 官網上就有的各種資料。
+
+主要是為了避免有人覺得「雖然是網站前端就有的資料，如果可以用 json 的格式拿到叫做安全漏洞」，所以加了這份文件把它變成 feature，不是很有用的一套 API。but still, like open source project always says, 'We are excited about what you will(can) build with it!'
+
 ## 更新網頁內容(免寫code!)
 
 ### 1. 大部分的文字、翻譯
@@ -56,8 +64,8 @@ vue webpack 模板文檔：[vuejs-templates/webpack](https://vuejs-templates.git
 ### Contribution
 本專案 follow [Vue.js 官方風格指南](https://cn.vuejs.org/v2/style-guide/) ，commit message 格式可以參考[這裏](https://gitmoji.carloscuesta.me/)，master 盡量以 merge 自己的 branch 代替直接 commit
 
-### Contributors
-@choznerol
+### Thank you, kind contributors!
+@yoyodiy
 
 @ooookai
 

--- a/apidoc.json
+++ b/apidoc.json
@@ -1,0 +1,9 @@
+{
+  "name": "API - g0v summit 2018",
+  "version": "0.1.0",
+  "description": "提供 2018 summit 官網上就有的各種資料。主要是為了避免有人覺得「雖然是網站前端就有的資料，如果可以用 json 的格式拿到叫做安全漏洞」，所以加了這份文件把它變成 feature，不是很有用的一套 API。but still, like open source project always says, 'We are excited about what you will(can) build with it!'",
+  "apidoc": {
+    "title": "API | g0v summit 2018",
+    "url": "http://summit.g0v.tw/2018/static/api"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "pull_airtable": "node ./scripts/pull_airtable.js",
     "build": "yarn pull_airtable && node build/build.js",
     "lint": "eslint --ext .js,.vue src",
-    "lint:fix": "eslint --fix --ext .js,.vue src "
+    "lint:fix": "eslint --fix --ext .js,.vue src ",
+    "apidoc": "apidoc -i static/ -o static/api/"
   },
   "dependencies": {
     "foundation-sites": "^6.4.3",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "airtable": "^0.5.6",
+    "apidoc": "^0.17.6",
     "autoprefixer": "^7.1.5",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",

--- a/scripts/pull_airtable.js
+++ b/scripts/pull_airtable.js
@@ -57,36 +57,3 @@ TABLE_NAMES.forEach(TABLE_NAME => {
       }
     )
 })
-
-// const TABLE_NAME = 'STREAMING'
-// let records = []
-
-// // called for every page of records
-// const processPage = (partialRecords, fetchNextPage) => {
-//   records = [...records, ...partialRecords]
-//   fetchNextPage()
-// }
-
-// // called when all the records have been retrieved
-// const processRecords = err => {
-//   if (err) {
-//     console.error(err)
-//   }
-
-//   const data = records.map(record => JSON.stringify(record.fields, null, 2))
-
-//   const filePath = path.resolve(__dirname, `${DIR_NAME}/${TABLE_NAME}.json`)
-//   fs.writeFile(filePath, `[${data}]`, err => {
-//     if (err) {
-//       console.error(err)
-//       return
-//     }
-//     console.log(`Saved records to ${DIR_NAME}/${TABLE_NAME}.json`)
-//   })
-// }
-
-// base(TABLE_NAME)
-//   .select({
-//     view: 'Grid view',
-//   })
-//   .eachPage(processPage, processRecords)

--- a/scripts/pull_airtable.js
+++ b/scripts/pull_airtable.js
@@ -3,13 +3,14 @@ const path = require('path')
 const Airtable = require('airtable')
 
 const TABLE_NAMES = [
-  'NEWS',
+  // 'NEWS',
   'SPONSORS',
   'SCHEDULE',
   'SPEAKERS',
-  'STREAMING',
+  // 'STREAMING',
   'STAFF',
-  'SOUVENIR',
+  // 'SOUVENIR',
+  // NOTE: 不要擔心 commend 掉的 table 裡沒什麼了不起的敏感資料，只是我現在還懶得寫它們的 doc，等用到時再說吧
 ]
 
 const DIR_NAME = '../static/airtable_data'

--- a/static/airtable_data/index.js
+++ b/static/airtable_data/index.js
@@ -3,7 +3,172 @@ import find from 'lodash/find'
 import assign from 'lodash/assign'
 import SPEAKERS from './SPEAKERS.json'
 import SCHEDULE from './SCHEDULE.json'
+
+/**
+ *
+ * @api {get} /static/airtable_data/SCHEDULE.json  Get /agenda page data
+ * @apiName getAgendaPageInfo
+ * @apiGroup agendaPage
+ *
+ * @apiSuccess {[]._id} id airtable ID of the record
+ * @apiSuccess {[].String} ID The official ID of the agendum in the brochure
+ * @apiSuccess {[].String} TITLE Displayed title of the agendum
+ * @apiSuccess {[].String} TITLE_EN Displayed title of the agendum (english version)
+ * @apiSuccess {[].String} ABSTRACT The brief description of this agendum
+ * @apiSuccess {[].String} ABSTRACT_EN The brief description of this agendum (english version)
+ * @apiSuccess {[].[String]} SPEAKER The airtable IDs of speakers
+ * @apiSuccess {[].String=R0, R1, R2, R3, ALL} VENUE The venue of the agendum (`ALL` just means a session that takes whole <tr> of the agenda table, like a keynote or lunch :P)
+ * @apiSuccess {[].String} START The start time of the agendum in ISODate
+ * @apiSuccess {[].String} END The end time of the agendum in ISODate
+ * @apiSuccess {[].String=talk, panel, workshop, keynote} TYPE The form of agendum
+ * @apiSuccess {[].Boolean} SHOW Whether the sponsor should be displayed
+ *
+ * @apiSuccessExample {json} Success-Response:
+ *    HTTP/1.1 200 OK
+ *    [
+ *       {
+ *           "id": "recEQLdDq2Sg9uRLa",
+ *           "TITLE": "開放政府聯絡人制度的挑戰與展望",
+ *           "VENUE": "R0",
+ *           "START": "2018-10-05T01:30:00.000Z",
+ *           "END": "2018-10-05T03:00:00.000Z",
+ *           "SPEAKER": [
+ *             "rec6sMP9TwkIQYfEk",
+ *             "recZuck1FGh5wUtli",
+ *             "recc0wWf8wLD5q6r5"
+ *           ],
+ *           "SHOW": true,
+ *           "TITLE_EN": "Participation Officer System: challenges and visions (translated)",
+ *           "ABSTRACT": "Participation officers network in Taiwanese government conduct workshops that engage diverse stakeholders to identify and define core problems, generate meaningful challenge statements, and co-create possible solutions to real issues and public projects. This process helps strengthen the quality of stakeholder collaborations and better inform our public policies. We believe that multi-stakeholder governance processes can reinforce the trust between citizens and the government.\n\nThe PO Network serves to drive cultural change; it plays a key role in Taiwan’s Open Government scene. POs are deeply involved in the conversation with civic society and governmental divisions, by tackling cross-ministerial issues with wider stakeholders openly and creatively. PO Network is a network of around 70 civil servants in the central government.",
+ *           "ABSTRACT_EN": "Participation officers network in Taiwanese government conduct workshops that engage diverse stakeholders to identify and define core problems, generate meaningful challenge statements, and co-create possible solutions to real issues and public projects. This process helps strengthen the quality of stakeholder collaborations and better inform our public policies. We believe that multi-stakeholder governance processes can reinforce the trust between citizens and the government.\n\nThe PO Network serves to drive cultural change; it plays a key role in Taiwan’s Open Government scene. POs are deeply involved in the conversation with civic society and governmental divisions, by tackling cross-ministerial issues with wider stakeholders openly and creatively. PO Network is a network of around 70 civil servants in the central government.",
+ *           "TYPE": "panel",
+ *           "ID": "125"
+ *       },
+ *       ...
+ *    ]
+ *
+ */
+export { default as SCHEDULE } from './SCHEDULE.json'
+
+/**
+ *
+ * @api {get} /static/airtable_data/SPEAKERS.json  Get /speakers page data
+ * @apiName getSpeakersPageInfo
+ * @apiGroup speakersPage
+ *
+ * @apiSuccess {[]._id} id airtable ID of the record
+ * @apiSuccess {[].String} ID The official ID of the speaker (e.g. in the brochure)
+ * @apiSuccess {[].String} NAME The display name of speaker
+ * @apiSuccess {[].String} NAME_EN Displayed The display name of speaker (english version)
+ * @apiSuccess {[].String} TITLE1 The 1st line of displayed title of the speaker
+ * @apiSuccess {[].String} TITLE1_EN The 1st line of displayed title of the speaker (english version)
+ * @apiSuccess {[].String} TITLE2 The 2nd line of displayed title of the speaker
+ * @apiSuccess {[].[String]} TITLE2_EN The 2nd line of displayed title of the speaker (english version)
+ * @apiSuccess {[].Object} CROPPED_AVATAR The avatar image of provided by speaker (See below tab 'Example of image object' for an example)
+ * @apiSuccess {[].[_id]} SCHEDULE The airtable IDs of his/her agendum(agenda)
+ * @apiSuccess {[].String} BIO The biography of the speaker
+ * @apiSuccess {[].String} TWITTER The twitter account shared by speaker
+ * @apiSuccess {[].Boolean} SHOW Whether the sponsor should be displayed
+ *
+ * @apiSuccessExample {json} Success-Response:
+ *    HTTP/1.1 200 OK
+ *    [
+ *       {
+ *           "id": "recPIVzZ2EoJi1FvT",
+ *           "NAME": "王小明",
+ *           "NAME_EN": "Ming Wong",
+ *           "TITLE1": "曉明大學開源社",
+ *           "TITLE1_EN": "XMUOSC",
+ *           "TITLE2": "社長",
+ *           "TITLE2_EN": "President"",
+ *           "CROPPED_AVATAR": [
+ *             "// See next tab 'Example of image object' for an example"
+ *           ],
+ *           "SCHEDULE": [
+ *             "recsqfmLaYIall9w7"
+ *           ],
+ *           "BIO": "小明是個3歲就開始寫code的開源大神，...",
+ *           "TWITTER": "@ming_wong_xmuosc",
+ *           "SHOW": true,
+ *           "ID": 666
+ *       },
+ *       ...
+ *    ]
+ *
+ * @apiUse ImageObject
+ *
+ */
+export { default as SPEAKERS } from './SPEAKERS.json'
+
+/**
+ *
+ * @api {get} /static/airtable_data/STAFF.json  Get /staff page data
+ * @apiName getStaffPageInfo
+ * @apiGroup staffPage
+ *
+ * @apiSuccess {[]._id} id airtable ID of the record
+ * @apiSuccess {[].String} NAME Displayed name of the staff
+ * @apiSuccess {[].String} NAME_EN Displayed name of the staff (english version)
+ * @apiSuccess {[].String} TITLE The displayed title of the staff
+ * @apiSuccess {[].String} TITLE_EN The displayed title of the staff (english version)
+ * @apiSuccess {[].String} GROUP The working group that the staff belongs to
+ * @apiSuccess {[].String} MAIN_GROUP The main working group that the staff belongs to (currently not displayed on the page)
+ *
+ * @apiSuccessExample {json} Success-Response:
+ *    HTTP/1.1 200 OK
+ *    [
+ *       {
+ *           id: "rec11WyYanU5Y0rJS",
+ *           NAME: "Lawrence",
+ *           TITLE: "網站",
+ *           TITLE_EN: "Website",
+ *           GROUP: "網站 APP 組",
+ *           NAME_EN: "Lawrence",
+ *           MAIN_GROUP: "宣傳大組"
+ *       },
+ *       ...
+ *    ]
+ *
+ */
 export { default as STAFF } from './STAFF.json'
+
+/**
+ *
+ * @api {get} /static/airtable_data/SPONSORS.json  Get /sponsor page data
+ * @apiName getSponsorPageInfo
+ * @apiGroup sponsorPage
+ *
+ * @apiSuccess {[]._id} id airtable ID of the record
+ * @apiSuccess {[].String} NAME-CH The working group that the sponsor belongs to
+ * @apiSuccess {[].String} NAME Displayed name of the sponsor (english version)
+ * @apiSuccess {[].String} BIO-CH Introduction of the sponsor
+ * @apiSuccess {[].String} BIO Introduction of the sponsor (english version)
+ * @apiSuccess {[].Object} CROPPED_LOGO The logo of sponsor (See below tab 'Example of image object' for an example)
+ * @apiSuccess {[].String=EVANGELIST, ACTIVIST, CIVICIST, SUPPORTER, IN_KIND, MEDIA_PARTNER, PROMOTING_PARTNER} CLASS The class of sponsor
+ * @apiSuccess {[].String} URL The website of sponsor
+ * @apiSuccess {[].Boolean} SHOW Whether the sponsor should be displayed
+ *
+ * @apiSuccessExample {json} Success-Response:
+ *    HTTP/1.1 200 OK
+ *    [
+ *       {
+ *           "id": "recZYSpM3N5ijS7ET",
+ *           "NAME": "Digital Taiwan Roundtable",
+ *           "BIO": "To enhance the competitiveness of Taiwan, we gathered people from the industry, government, universities, and research institutes to established the national “Digital Taiwan Roundtable” to bring together all the professionals and intelligence. We advocate the required adjustments of regulations and policies for digital transformation in industries and the society.  *           \nDigital Taiwan Roundtable is a non-profit organization. Its mission is to promote the development of digital technology in various industries and to advice the government in formulating proactive policies, in order to enhance the international competitiveness advantages in digital technology related industries. ",
+ *           "CROPPED_LOGO": [
+ *             "// See next tab 'Example of image object' for an example"
+ *           ],
+ *           "CLASS": "EVANGELIST",
+ *           "NAME-CH": "台灣數位科技與政策協進會",
+ *           "BIO-CH": "基於數位科技對於台灣競爭力之重要性，我們結合具共同理念與理想的產、官、學、研人士，成立全國性的「台灣數位科技與政策協進會」，期望藉此匯集專業與智慧，整合數位科技對各行各業發展所需的法規與政策，對政府建言並提供各界參考，以產生對數位科技產業進行結構性翻轉的效益。\n本會為依法設立，非以營利為目的之社會團體，以促進各行各業結合數位科技發展，及建議政府制定前瞻性相關政策，促使數位科技相關產業具國際競爭優勢為宗旨。",
+ *           "URL": "https://digitaltaiwan.org/",
+ *           "SHOW": true
+ *       },
+ *       ...
+ *    ]
+ * @apiUse ImageObject
+ *
+ */
 export { default as SPONSORS } from './SPONSORS.json'
 
 /**
@@ -28,6 +193,43 @@ export const populateRecord = (record, path, linkedRecords) => {
 export const populateRecords = (records, path, linkedRecords) =>
   records.map(record => populateRecord(record, path, linkedRecords))
 
-export const POPULATED_SPEAKERS = populateRecords(SPEAKERS, 'SCHEDULE', SCHEDULE)
+export const POPULATED_SPEAKERS = populateRecords(
+  SPEAKERS,
+  'SCHEDULE',
+  SCHEDULE
+)
 
 export const POPULATED_SCHEDULE = populateRecords(SCHEDULE, 'SPEAKER', SPEAKERS)
+
+/**
+ * @apiDefine ImageObject
+ * @apiSuccessExample {Object} Example of image object
+ * [
+ *     ...
+ *     [KEY]: {
+ *       "id": "attgkp5Ay0Y9vn5S3",
+ *       "url": "https://dl.airtable.com/YReBtbvKTomXClPuVyn4_FILENAME.png",
+ *       "filename": "FILENAME.png",
+ *       "size": 12345,
+ *       "type": "image/png",
+ *       "thumbnails": {
+ *         "small": {
+ *           "url": "https://dl.airtable.com/urqTHApBRhajDS14xPWl_small_FILENAME.png",
+ *           "width": 68,
+ *           "height": 36
+ *         },
+ *         "large": {
+ *           "url": "https://dl.airtable.com/HRZneuQj2EQ01CPdZD1w_large_FILENAME.png",
+ *           "width": 263,
+ *           "height": 140
+ *         },
+ *         "full": {
+ *           "url": "https://dl.airtable.com/G4BW3NfqR2a5QxpuqiEu_full_FILENAME.png",
+ *           "width": 263,
+ *           "height": 140
+ *         }
+ *       }
+ *     }
+ *     ...
+ * ]
+ */

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -259,6 +263,28 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+apidoc-core@~0.8.2:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/apidoc-core/-/apidoc-core-0.8.3.tgz#d9d63545829df250d2cca049683a87e775364b96"
+  dependencies:
+    fs-extra "^3.0.1"
+    glob "^7.1.1"
+    iconv-lite "^0.4.17"
+    klaw-sync "^2.1.0"
+    lodash "~4.17.4"
+    semver "~5.3.0"
+
+apidoc@^0.17.6:
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/apidoc/-/apidoc-0.17.6.tgz#4ee8ac610dedddcb1006c3e28fa7dd634b4a5ce6"
+  dependencies:
+    apidoc-core "~0.8.2"
+    fs-extra "~3.0.1"
+    lodash "~4.17.4"
+    markdown-it "^8.3.1"
+    nomnom "~1.8.1"
+    winston "~2.3.1"
 
 append-transform@^1.0.0:
   version "1.0.0"
@@ -408,6 +434,10 @@ async@^2.1.4:
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
     lodash "^4.17.10"
+
+async@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1525,6 +1555,14 @@ chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
+
 character-parser@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/character-parser/-/character-parser-2.2.0.tgz#c7ce28f36d4bcd9744e5ffc2c5fcde1c73261fc0"
@@ -1728,6 +1766,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2091,6 +2133,10 @@ currently-unhandled@^0.4.1:
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
   dependencies:
     array-find-index "^1.0.1"
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
 cyclist@~0.2.2:
   version "0.2.2"
@@ -3037,6 +3083,10 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
@@ -3306,7 +3356,7 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^3.0.1:
+fs-extra@^3.0.1, fs-extra@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:
@@ -3667,6 +3717,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -4415,7 +4469,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isstream@~0.1.2:
+isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
@@ -5010,6 +5064,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+klaw-sync@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-2.1.0.tgz#3d3bcd8600e7bfdef53231c739ff053aed560e44"
+  optionalDependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -5069,6 +5129,12 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -5390,6 +5456,16 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^8.3.1:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -5400,6 +5476,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5875,6 +5955,13 @@ node-sass@^4.5.3:
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
+
+nomnom@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -7928,6 +8015,10 @@ ssri@^5.0.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -8057,6 +8148,10 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
@@ -8426,6 +8521,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
+
 uglify-es@^3.1.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.7.tgz#d1249af668666aba7cb1163e277455be9eb393cf"
@@ -8468,6 +8567,10 @@ uid-number@^0.0.6:
 ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -8889,6 +8992,17 @@ widest-line@^1.0.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+winston@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.3.1.tgz#0b48420d978c01804cf0230b648861598225a119"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
 
 with@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
提供 2018 summit 官網上就有的各種資料。

主要是為了避免有人覺得「雖然是網站前端就有的資料，如果可以用 json 的格式拿到叫做安全漏洞」，所以加了這份文件把它變成 feature，不是很有用的一套 API。but still, like open source project always says, 'We are excited about what you will(can) build with it!'