### PR TITLE
新增「開放工作坊」、「大會共筆」、「口譯連結」、「直播資訊」、「社群動態」等連結

### DIFF
--- a/src/components/AgendumCell.vue
+++ b/src/components/AgendumCell.vue
@@ -4,7 +4,7 @@
     :class="['agendum-cell-link', { 'pointer': shouldShowDialog }]"
     :role="shouldShowDialog && 'link'"
     tabindex="0"
-    @click.stop="goToAgendum"
+    @click.stop="onAgendumCellClick"
   >
     <div class="agendum-cell">
       <div class="fixed-cell-top">
@@ -188,12 +188,14 @@ export default {
     }
   },
   methods: {
-    goToAgendum() {
+    onAgendumCellClick() {
       if (this.shouldShowDialog) {
         router.push({
           name: 'AgendaPage',
           params: { agendumIdOrDay: this.agendum.id, slug: this.slug },
         })
+      } else if (has(this.agendum, 'DESCRIPTION_LINK')) {
+        window.open(this.agendum.DESCRIPTION_LINK, '_blank')
       }
     },
     openTooltip() {

--- a/src/components/UnderlineLink.vue
+++ b/src/components/UnderlineLink.vue
@@ -1,9 +1,17 @@
 <template>
-  <router-link :to="to">
+  <router-link v-if="!!to" :to="to">
     <span id="wrapper">
       <slot/>
     </span>
   </router-link>
+  <a v-else-if="!!href" :href="href" target="_blank">
+    <span id="wrapper">
+      <slot/>
+    </span>
+  </a>
+  <span v-else id="wrapper">
+    <slot/>
+  </span>
 </template>
 
 <script>
@@ -12,7 +20,11 @@ export default {
   props: {
     to: {
       type: String,
-      required: true,
+      default: null,
+    },
+    href: {
+      type: String,
+      default: null,
     },
   },
 }

--- a/src/components/VueResponsiveTimeline.vue
+++ b/src/components/VueResponsiveTimeline.vue
@@ -13,7 +13,7 @@
     >
       <template v-for="(item, index) in sortedItems">
         <li
-          :key="item.title"
+          :key="`${item.title} ${item.subtitle}`"
           :style="{
             gridArea: `evt${index}`,
             position: 'relative',

--- a/src/pages/AgendaPage.vue
+++ b/src/pages/AgendaPage.vue
@@ -1,17 +1,30 @@
 <template>
   <div id="AgendaPage" class="grid-x align-center">
-    <section v-close-popover id="agenda" class="cell large-10">
+    <section v-close-popover id="agenda" class="cell large-10 margin-bottom-3">
+      <div class="text-center h5 margin-top-2 margin-bottom-3">
+        <a href="https://g0v.hackmd.io/c/summit18" target="_blank">
+          <TW>大會共筆</TW>
+          <EN>Collaboration Notes</EN>
+        </a>
+        &nbsp;|&nbsp;
+        <a href="https://beta.hackfoldr.org/g0v-Summit-2018-unconf" target="_blank">
+          <TW>開放參與</TW>
+          <EN>Open Participation</EN>
+        </a>
+        &nbsp;|&nbsp;
+        <a href="https://g0v.auxala.com" target="_blank">
+          <TW>即時口譯</TW>
+          <EN>Realtime Interpretation</EN>
+        </a>
+      </div>
       <CapsuleRadioButton
         id="date-picker"
         :options="dates"
         v-model="activeDate"
+        class="margin-bottom-2"
         lazy
         debounce="500"
       />
-      <div class="text-center h5 padding-bottom-2">
-        <TW>大會議程皆有華英語雙向即時口譯</TW>
-        <EN>All sessions will have simultaneous bidirectional interpretation between English and Mandarin</EN>
-      </div>
       <div id="parallel-agenda-wrapper">
         <ParallelAgenda
           id="parallel-agenda"
@@ -162,10 +175,6 @@ export default {
 
 <style lang="scss" scoped>
 section#agenda {
-  margin: 10px 0 120px;
-  #date-picker {
-    margin: 100px 0 20px 0;
-  }
   #parallel-agenda-wrapper {
     overflow-x: scroll;
     #parallel-agenda {

--- a/src/pages/CallForPaperPage.vue
+++ b/src/pages/CallForPaperPage.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  #call-for-paper-page.mb-50
+  #call-for-paper-page.margin-bottom-3
     .grid-y
       .cell
         .grid-x.grid-padding-x.grid-margin-x

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
   #LandingPage
-    HeroImage(class="mb-150")
-    #event-intro.grid-y.align-middle.mb-50
+    HeroImage.hero-image
+    #event-intro.grid-y.align-middle.margin-bottom-3
       //- 社群簡介
-      section.mb-50
+      section.margin-bottom-3
         TW
           h1 社群簡介
           p 自 2012 年以來，公民科技運動風起雲湧，以開放透明、公民參與為號召的 g0v 台灣零時政府社群號召了第一場活動，以「寫程式改造社會」為口號，從此開始公民科技之火開始延燒，至今未歇。
@@ -15,7 +15,7 @@
           p Established in 2012, g0v has since hosted over 50 hackathons and two international summits. Thousands of participants from different backgrounds have contributed to hundreds of projects, making g0v one of the biggest civic tech communities around the world.
 
       //- 雙年會簡介
-      section.mb-50
+      section.margin-bottom-3
         TW
           h1 雙年會簡介
           p g0v 國際雙年會兩年舉辦一次，關注開放政府、開源協作、公民參與等面向，是國際開放政府社群的焦點活動，過去兩屆吸引多達十九國講者投稿。雙年會全部由社群參與者志願籌辦，議程也秉持開放協作精神，全部議程皆有口譯、文字記錄和直播。議程除了大會籌辦，也開放完整時段的開放工作坊（Unconference）由參與者提案決定議程內容，以演講、討論、自由對話等形式創造新的協作空間。閉幕前自由報名的全場閃電講更是開源社群傳統，以開放分享的精神貫穿年會。
@@ -38,7 +38,7 @@
             router-link(:to="{ name: 'CallForPaperPage' }") Call For Paper (Closed)
 
       //- 行為準則
-      section.mb-50
+      section.margin-bottom-3
         TW
           h1 行為準則
           p 所有參與本次活動的出席者，講員，贊助人，志工均應同意遵守下列的行為規範。活動總召將在活動過程中執行這些規範。我們期望所有參與者共同合作，提供一個安全的環境給大家。
@@ -76,17 +76,17 @@
           p Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
           p We expect participants to follow these rules at conference and workshop venues and conference-related social events.
 
-    #timeline-wrapper.mb-50
+    #timeline-wrapper.margin-bottom-3
       section#timeline
         VueResponsiveTimeline(:items="timelineItems" :breakpoint="1024")
 
-    #summit-highlight.grid-y.align-middle.mb-50
+    #summit-highlight.grid-y.align-middle.margin-bottom-3
 
       section#keynotes
         h1
           TW 2018 Keynote
           EN 2018 Keynote
-        .grid-x.align-justify.grid-margin-x.mb-50
+        .grid-x.align-justify.grid-margin-x.margin-bottom-3
           template(v-for="keynote in keynotes")
             KeynoteBrief(:keynote="keynote").cell.large-6.medium-6.flex-child-shrink
 
@@ -94,7 +94,7 @@
         h1
           TW 歷年講者
           EN Past Speakers
-        .grid-x.align-justify.grid-margin-x.mb-50
+        .grid-x.align-justify.grid-margin-x.margin-bottom-3
           template(v-for="speaker in speakers")
             SpeakerBrief(:speaker="speaker").cell.large-4.medium-6.flex-child-shrink
 
@@ -102,7 +102,7 @@
         h1
           TW 媒體報導
           EN Media Coverage
-        .grid-x.align-justify.grid-margin-x.mb-50
+        .grid-x.align-justify.grid-margin-x.margin-bottom-3
           .media-object(v-for="report in reports").large-4.stack-for-small
             .media-object-section
               MediaQuote(:report="report")
@@ -229,6 +229,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.hero-image {
+  margin-bottom: 5rem;
+}
+
 #timeline-wrapper {
   background-color: #e7e7e7;
   padding: 100px 1rem;

--- a/src/pages/SponsorPage.vue
+++ b/src/pages/SponsorPage.vue
@@ -61,7 +61,7 @@
                 TW {{ sponsor['NAME-CH'] }}
 
     //- 贊助按鈕
-    .cell.text-center.mb-50
+    .cell.text-center.margin-bottom-3
       CtaButton(
           href=`mailto:g0v-summit-partner-2018@googlegroups.com?subject=${encodeURIComponent('成為 g0v summit 2018 贊助夥伴')}`
           hoverText="g0v-summit-partner-2018@googlegroups.com"

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -43,14 +43,6 @@ section {
   outline: 1px dashed green;
 }
 
-// .mb-25, .mb-50, .mb-75, .mb-100, .mb-125, .mb-150
-$margins: 25, 50, 75, 100, 125, 150;
-@each $margin in $margins {
-  .mb-#{$margin} {
-    margin-bottom:  #{$margin}px;
-  }
-}
-
 .v-align-child-middle > * {
   vertical-align: middle;
 }

--- a/src/views/NavBar.vue
+++ b/src/views/NavBar.vue
@@ -31,10 +31,17 @@
           UnderlineLink(to="/transport")
             TW 交通
             EN Transport
-        //- li
-        //-   UnderlineLink(to="/live")
-        //-     TW 直撥
-        //-     EN Live
+        li
+          //- TODO: Embed streamming in page /live
+          //- UnderlineLink(to="/live")
+          UnderlineLink(href="https://www.youtube.com/user/g0vTW")
+            TW 直撥
+            EN Live
+        li
+          //- TODO: Embed content in site
+          UnderlineLink(href="https://www.juicer.io/g0vsummit")
+            TW 社群動態
+            EN Feed
         li
           UnderlineLink(to="/staff")
             TW 工作人員


### PR DESCRIPTION
Close #188 
@ipaaa 看`社群動態`翻成`Feed`有沒有要調整（但盡可能不要太長）
@chihaoyo 我直接照 hackflr 裡的連結翻 `開放參與` 跟 `Open Participation`，看有沒有要調整。另外 Airtable 裡新增了 `SCHEDULE.DESCRIPTION_LINK` 所以點 unconf 或 BoF 的格子也會連到那邊

![image](https://user-images.githubusercontent.com/12410942/46241237-f7612280-c3e7-11e8-9e51-4ae53d67b27a.png)
![image](https://user-images.githubusercontent.com/12410942/46241240-fd570380-c3e7-11e8-8969-2bfd08d144f1.png)

